### PR TITLE
fixed video highlight issue referenced in #387

### DIFF
--- a/animate.css
+++ b/animate.css
@@ -10,8 +10,8 @@ Copyright (c) 2015 Daniel Eden
 .animated {
   -webkit-animation-duration: 1s;
   animation-duration: 1s;
-  -webkit-animation-fill-mode: both;
-  animation-fill-mode: both;
+  -webkit-animation-fill-mode: none;
+  animation-fill-mode: none;
 }
 
 .animated.infinite {


### PR DESCRIPTION
When a container containing a video is animated, the video cannot go full screen.
